### PR TITLE
Fix RenderLayers.getBlockLayer returning solid for everything

### DIFF
--- a/fabric-blockrenderlayer-v1/src/client/java/net/fabricmc/fabric/impl/blockrenderlayer/ExtendedChunkRenderTypeSet.java
+++ b/fabric-blockrenderlayer-v1/src/client/java/net/fabricmc/fabric/impl/blockrenderlayer/ExtendedChunkRenderTypeSet.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.blockrenderlayer;
+
+import net.minecraft.client.render.RenderLayer;
+
+public interface ExtendedChunkRenderTypeSet {
+	RenderLayer sinytra$firstLayer();
+}

--- a/fabric-blockrenderlayer-v1/src/client/java/net/fabricmc/fabric/mixin/blockrenderlayer/ChunkRenderTypeSetMixin.java
+++ b/fabric-blockrenderlayer-v1/src/client/java/net/fabricmc/fabric/mixin/blockrenderlayer/ChunkRenderTypeSetMixin.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.blockrenderlayer;
+
+import net.fabricmc.fabric.impl.blockrenderlayer.ExtendedChunkRenderTypeSet;
+
+import net.minecraft.client.render.RenderLayer;
+
+import net.minecraftforge.client.ChunkRenderTypeSet;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.BitSet;
+
+@Mixin(ChunkRenderTypeSet.class)
+public abstract class ChunkRenderTypeSetMixin implements ExtendedChunkRenderTypeSet {
+
+	@Shadow
+	public abstract boolean isEmpty();
+
+	@Shadow
+	@Final
+	private BitSet bits;
+
+	@Shadow
+	@Final
+	private static RenderLayer[] CHUNK_RENDER_TYPES;
+
+	@Override
+	public RenderLayer sinytra$firstLayer() {
+		if(isEmpty())
+			return RenderLayer.getSolid();
+		return CHUNK_RENDER_TYPES[bits.nextSetBit(0)];
+	}
+}

--- a/fabric-blockrenderlayer-v1/src/client/java/net/fabricmc/fabric/mixin/blockrenderlayer/RenderLayersMixin.java
+++ b/fabric-blockrenderlayer-v1/src/client/java/net/fabricmc/fabric/mixin/blockrenderlayer/RenderLayersMixin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.blockrenderlayer;
+
+import net.fabricmc.fabric.impl.blockrenderlayer.ExtendedChunkRenderTypeSet;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.render.RenderLayers;
+
+import net.minecraft.registry.entry.RegistryEntry;
+
+import net.minecraftforge.client.ChunkRenderTypeSet;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.Map;
+
+@Mixin(RenderLayers.class)
+public class RenderLayersMixin {
+	@Shadow
+	@Final
+	private static Map<RegistryEntry.Reference<Block>, ChunkRenderTypeSet> BLOCK_RENDER_TYPES;
+
+	/**
+	 * @author embeddedt
+	 * @reason Make getBlockLayer behave correctly (so that it can be used by Fabric mods) as long as the block has
+	 * only a single render type
+	 */
+	@Redirect(method = {"getBlockLayer", "getMovingBlockLayer" }, at = @At(value = "INVOKE", target = "Ljava/util/Map;get(Ljava/lang/Object;)Ljava/lang/Object;", ordinal = 0))
+	private static Object getRenderLayerViaForge(Map instance, Object block) {
+		ChunkRenderTypeSet renderTypeSet = BLOCK_RENDER_TYPES.get(ForgeRegistries.BLOCKS.getDelegateOrThrow((Block)block));
+		return ((ExtendedChunkRenderTypeSet)(Object)renderTypeSet).sinytra$firstLayer();
+	}
+}

--- a/fabric-blockrenderlayer-v1/src/client/resources/fabric-blockrenderlayer-v1.mixins.json
+++ b/fabric-blockrenderlayer-v1/src/client/resources/fabric-blockrenderlayer-v1.mixins.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "package": "net.fabricmc.fabric.mixin.blockrenderlayer",
+  "compatibilityLevel": "JAVA_17",
+  "client": [
+    "ChunkRenderTypeSetMixin",
+    "RenderLayersMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1,
+    "maxShiftBy": 3
+  },
+  "minVersion": "0.8.5"
+}

--- a/fabric-blockrenderlayer-v1/src/client/resources/fabric.mod.json
+++ b/fabric-blockrenderlayer-v1/src/client/resources/fabric.mod.json
@@ -21,6 +21,9 @@
     "fabric-api-base": "*"
   },
   "description": "Registration utility for block and fluid render layers.",
+  "mixins": [
+    "fabric-blockrenderlayer-v1.mixins.json"
+  ],
   "custom": {
     "fabric-api:module-lifecycle": "stable"
   }

--- a/fabric-blockrenderlayer-v1/src/testmod/java/net/fabricmc/fabric/test/blockrenderlayer/BlockRenderLayerTest.java
+++ b/fabric-blockrenderlayer-v1/src/testmod/java/net/fabricmc/fabric/test/blockrenderlayer/BlockRenderLayerTest.java
@@ -60,6 +60,9 @@ public class BlockRenderLayerTest {
             if (RenderLayers.getFluidLayer(EXAMPLE_FLUID.get().getDefaultState()) != RenderLayer.getTranslucent()) {
                 throw new AssertionError("Expected render type of EXAMPLE_FLUID to be RenderType.translucent");
             }
+            if (RenderLayers.getBlockLayer(EXAMPLE_BLOCK.get().getDefaultState()) != RenderLayer.getCutout()) {
+				throw new AssertionError("Expected EXAMPLE_BLOCK to be RenderType.cutout");
+            }
 
             // Success!
             LOGGER.info("The tests for block render type layers passed!");


### PR DESCRIPTION
Forge does not populate the `BLOCKS` map in `RenderLayers`. This means that `RenderLayers.getBlockLayer` returns solid for any modded block. Evidently, Forge expects modders to be using the new `RenderLayers.getRenderLayers` function they patch in, however, Fabric mods will all be using `getBlockLayer` since that is correct for vanilla. Hence, we need to provide a reasonable fallback.

The approach I used is to return the first render type in the `ChunkRenderTypeSet`; this will work correctly on most blocks. It's quite a bit of a kludge, but better than nothing. The mixin on `ChunkRenderTypeSet` is necessary to avoid an iterator allocation on every call.