### PR TITLE
Replace some vanilla API calls with Forge equivalents

### DIFF
--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/compat/WrappedInventory.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/compat/WrappedInventory.java
@@ -61,7 +61,7 @@ final class WrappedInventory implements ItemInsertable, ItemExtractable {
 				ItemStack stack = inv.getStack(i);
 
 				if (stack.isEmpty() || ItemStack.canCombine(stack, input)) {
-					int remainingSpace = Math.min(inv.getMaxCountPerStack(), stack.getItem().getMaxStackSize(stack)) - stack.getCount();
+					int remainingSpace = Math.min(inv.getMaxCountPerStack(), stack.getMaxCount()) - stack.getCount();
 					int inserted = Math.min(remainingSpace, input.getCount());
 
 					if (!simulate) {

--- a/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/compat/WrappedInventory.java
+++ b/fabric-api-lookup-api-v1/src/testmod/java/net/fabricmc/fabric/test/lookup/compat/WrappedInventory.java
@@ -61,7 +61,7 @@ final class WrappedInventory implements ItemInsertable, ItemExtractable {
 				ItemStack stack = inv.getStack(i);
 
 				if (stack.isEmpty() || ItemStack.canCombine(stack, input)) {
-					int remainingSpace = Math.min(inv.getMaxCountPerStack(), stack.getItem().getMaxCount()) - stack.getCount();
+					int remainingSpace = Math.min(inv.getMaxCountPerStack(), stack.getItem().getMaxStackSize(stack)) - stack.getCount();
 					int inserted = Math.min(remainingSpace, input.getCount());
 
 					if (!simulate) {

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/aocalc/AoCalculator.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/aocalc/AoCalculator.java
@@ -528,7 +528,7 @@ public abstract class AoCalculator {
 			// See AoCalculator#meanBrightness.
 			int i = world.getLightLevel(LightType.SKY, pos);
 			int j = world.getLightLevel(LightType.BLOCK, pos);
-			int k = state.getLuminance();
+			int k = state.getLightEmission(world, pos);
 
 			if (j < k) {
 				j = k;

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/aocalc/AoLuminanceFix.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/aocalc/AoLuminanceFix.java
@@ -37,6 +37,6 @@ public interface AoLuminanceFix {
 	}
 
 	static float fixed(BlockView view, BlockPos pos, BlockState state) {
-		return state.getLuminance() == 0 ? state.getAmbientOcclusionLightLevel(view, pos) : 1f;
+		return state.getLightEmission(view, pos) == 0 ? state.getAmbientOcclusionLightLevel(view, pos) : 1f;
 	}
 }

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/BlockRenderInfo.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/BlockRenderInfo.java
@@ -84,7 +84,7 @@ public class BlockRenderInfo {
 		this.blockState = blockState;
 
 		useAo = MinecraftClient.isAmbientOcclusionEnabled();
-		defaultAo = useAo && modelAo && blockState.getLuminance() == 0;
+		defaultAo = useAo && modelAo && blockState.getLightEmission(this.blockView, blockPos) == 0;
 
 		blockModelData = modelData;
 		defaultLayer = renderLayer;

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleStackStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleStackStorage.java
@@ -80,7 +80,7 @@ public abstract class SingleStackStorage extends SnapshotParticipant<ItemStack> 
 	 * @return The maximum capacity of this storage for the passed item variant.
 	 */
 	protected int getCapacity(ItemVariant itemVariant) {
-		return itemVariant.getItem().getMaxStackSize(itemVariant.toStack());
+		return itemVariant.toStack().getMaxCount();
 	}
 
 	@Override

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleStackStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/api/transfer/v1/item/base/SingleStackStorage.java
@@ -80,7 +80,7 @@ public abstract class SingleStackStorage extends SnapshotParticipant<ItemStack> 
 	 * @return The maximum capacity of this storage for the passed item variant.
 	 */
 	protected int getCapacity(ItemVariant itemVariant) {
-		return itemVariant.getItem().getMaxCount();
+		return itemVariant.getItem().getMaxStackSize(itemVariant.toStack());
 	}
 
 	@Override

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/PlayerInventoryStorageImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/PlayerInventoryStorageImpl.java
@@ -132,7 +132,7 @@ class PlayerInventoryStorageImpl extends InventoryStorageImpl implements PlayerI
 				long remainder = entry.amount;
 
 				while (remainder > 0) {
-					int dropped = (int) Math.min(entry.key.getItem().getMaxStackSize(entry.key.toStack()), remainder);
+					int dropped = (int) Math.min(entry.key.toStack().getMaxCount(), remainder);
 					playerInventory.player.dropItem(entry.key.toStack(dropped), entry.throwRandomly, entry.retainOwnership);
 					remainder -= dropped;
 				}

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/PlayerInventoryStorageImpl.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/PlayerInventoryStorageImpl.java
@@ -132,7 +132,7 @@ class PlayerInventoryStorageImpl extends InventoryStorageImpl implements PlayerI
 				long remainder = entry.amount;
 
 				while (remainder > 0) {
-					int dropped = (int) Math.min(entry.key.getItem().getMaxCount(), remainder);
+					int dropped = (int) Math.min(entry.key.getItem().getMaxStackSize(entry.key.toStack()), remainder);
 					playerInventory.player.dropItem(entry.key.toStack(dropped), entry.throwRandomly, entry.retainOwnership);
 					remainder -= dropped;
 				}


### PR DESCRIPTION
Detected these by scanning for calls to deprecated APIs and then manually poring through the list. Most of the deprecations were irrelevant (e.g. registries) but I found a couple that seem worth fixing. By default these methods delegate back to exactly the API Fabric would have called so there should be no compatibility issues introduced with Fabric mods.