### PR TITLE
Removed non-applicable & confusing line in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,6 @@ The Forgified Fabric API is available for download on the following platforms:
 - [CurseForge](https://www.curseforge.com/minecraft/mc-mods/forgified-fabric-api)
 - [Modrinth](https://modrinth.com/mod/forgified-fabric-api)
 
-To use Forgified Fabric API, download it from .
-Standalone CurseForge and Modrinth distributions will be available soon.
-
 The downloaded jar file should be placed in your `mods` folder.
 
 ## Using Forgified Fabric API to develop mods


### PR DESCRIPTION
I was very confused why the line existed before it hit me that this may have been useful before, but it lost its purpose and was never removed for some reason?