### PR TITLE
Fixes for TechReborn

### DIFF
--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java
@@ -95,8 +95,16 @@ public class FabricBlockSettings extends BlockBehaviour.Properties {
 	 * @deprecated replace with {@link BlockBehaviour.Properties#of()}
 	 */
 	@Deprecated
-	public static FabricBlockSettings of() {
+	public static FabricBlockSettings create() {
 		return new FabricBlockSettings();
+	}
+
+	/**
+	 * @deprecated replace with {@link BlockBehaviour.Properties#of()}
+	 */
+	@Deprecated
+	public static FabricBlockSettings of() {
+		return create();
 	}
 
 	/**


### PR DESCRIPTION
It crashes with:
```
Caused by: java.lang.NoSuchMethodError: 'net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings.create()'
        at TRANSFORMER/techreborn@5.11.9/techreborn.init.TRBlockSettings.ore(TRBlockSettings.java:160) ~[TechReborn-5.11.9_mapped_moj_1.21.jar%23390!/:?] {re:classloading}
```
However, it also requires `Fabric Rendering Data Attachment (v1)` but you can easily extract it from the original fabric-api (it will work fine):
![2024-07-22_03 07 18](https://github.com/user-attachments/assets/e5be1d26-5d27-4758-9206-24ed2c492284)
