### PR TITLE
Fix connection to vanilla servers

### DIFF
--- a/fabric-networking-api-v1/src/main/java/org/sinytra/fabric/networking_api/NeoNetworkRegistrar.java
+++ b/fabric-networking-api-v1/src/main/java/org/sinytra/fabric/networking_api/NeoNetworkRegistrar.java
@@ -100,7 +100,7 @@ public class NeoNetworkRegistrar {
             boolean setup = NetworkRegistryAccessor.getSetup();
 
             NetworkRegistryAccessor.setSetup(false);
-            NetworkRegistry.register(type, (StreamCodec<? super FriendlyByteBuf, PAYLOAD>) DUMMY_CODEC, handler, List.of(protocol), Optional.empty(), "1.0", setup);
+            NetworkRegistry.register(type, (StreamCodec<? super FriendlyByteBuf, PAYLOAD>) DUMMY_CODEC, handler, List.of(protocol), Optional.empty(), "1.0", true);
             NetworkRegistryAccessor.setSetup(setup);
 
             // TODO Send registration message when registering late


### PR DESCRIPTION
The last field of this method indicates that the channel may be optional, but NFFAPI sets it to false, resulting in:
![2024-08-11_12 53 27](https://github.com/user-attachments/assets/8f1b72dc-6260-45fd-a3cc-5b6d29384849)