### PR TITLE
[1.21.1] Adjust applyOverlayConditions mixin target to specific ordinal

### DIFF
--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/mixin/resource/conditions/ResourcePackProfileMixin.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/mixin/resource/conditions/ResourcePackProfileMixin.java
@@ -30,7 +30,7 @@ import net.minecraft.server.packs.repository.Pack;
 
 @Mixin(Pack.class)
 public class ResourcePackProfileMixin {
-	@ModifyVariable(method = "readPackMetadata", at = @At("STORE"))
+	@ModifyVariable(method = "readPackMetadata", at = @At(value = "STORE", ordinal = 0))
 	private static List<String> applyOverlayConditions(List<String> overlays, @Local PackResources resourcePack) throws IOException {
 		List<String> appliedOverlays = new ArrayList<>(overlays);
 		OverlayConditionsMetadata overlayMetadata = resourcePack.getMetadataSection(OverlayConditionsMetadata.SERIALIZER);


### PR DESCRIPTION
Fixes world loading failure where changes Neos List copy to immutable leading to crashes, a for sure fix is still needed for when both loader conditions are found when such is only a neo mod. Fixes https://github.com/Sinytra/ForgifiedFabricAPI/issues/151