### PR TITLE
Use the holding `LivingEntity` instance for `EquipmentSlotProvider#getPreferredEquipmentSlot` in `IItemExtensionMixin#getEquipmentSlot`

### DIFF
--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/ItemStackExtensions.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/ItemStackExtensions.java
@@ -1,0 +1,9 @@
+package net.fabricmc.fabric.impl.item;
+
+import net.minecraft.world.entity.LivingEntity;
+import org.jetbrains.annotations.Nullable;
+
+public interface ItemStackExtensions {
+	@Nullable LivingEntity fabric_getLivingEntity();
+	void fabric_setLivingEntity(LivingEntity livingEntity);
+}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/IItemExtensionMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/IItemExtensionMixin.java
@@ -3,9 +3,9 @@ package net.fabricmc.fabric.mixin.item;
 import net.fabricmc.fabric.api.item.v1.EquipmentSlotProvider;
 import net.fabricmc.fabric.api.item.v1.FabricItem;
 import net.fabricmc.fabric.impl.item.ItemExtensions;
+import net.fabricmc.fabric.impl.item.ItemStackExtensions;
 import net.fabricmc.fabric.impl.item.RecursivityHelper;
 import net.minecraft.world.entity.EquipmentSlot;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.common.extensions.IItemExtension;
 import org.spongepowered.asm.mixin.Mixin;
@@ -31,12 +31,12 @@ public interface IItemExtensionMixin extends FabricItem {
         }
     }
 
-    @Inject(method = "getEquipmentSlot", at = @At("HEAD"))
+    @Inject(method = "getEquipmentSlot", at = @At("HEAD"), cancellable = true)
     default void getEquipmentSlot(ItemStack stack, CallbackInfoReturnable<EquipmentSlot> cir) {
         EquipmentSlotProvider equipmentSlotProvider = ((ItemExtensions) this).fabric_getEquipmentSlotProvider();
 
         if (equipmentSlotProvider != null) {
-            cir.setReturnValue(equipmentSlotProvider.getPreferredEquipmentSlot((LivingEntity) this, stack));
+            cir.setReturnValue(equipmentSlotProvider.getPreferredEquipmentSlot(((ItemStackExtensions) (Object) stack).fabric_getLivingEntity(), stack));
         }
     }
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemStackMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/ItemStackMixin.java
@@ -21,9 +21,12 @@ import java.util.function.Consumer;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
+import net.fabricmc.fabric.impl.item.ItemStackExtensions;
 import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import net.fabricmc.fabric.api.item.v1.CustomDamageHandler;
 import net.fabricmc.fabric.api.item.v1.FabricItemStack;
@@ -35,7 +38,11 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 
 @Mixin(ItemStack.class)
-public abstract class ItemStackMixin implements FabricItemStack {
+public abstract class ItemStackMixin implements ItemStackExtensions, FabricItemStack {
+	@Unique
+	@Nullable
+	private LivingEntity livingEntity;
+
 	@Shadow
 	public abstract Item getItem();
 
@@ -68,5 +75,15 @@ public abstract class ItemStackMixin implements FabricItemStack {
 		}
 
 		original.call(instance, amount, serverWorld, serverPlayerEntity, consumer);
+	}
+
+	@Override
+	public @Nullable LivingEntity fabric_getLivingEntity() {
+		return livingEntity;
+	}
+
+	@Override
+	public void fabric_setLivingEntity(LivingEntity livingEntity) {
+		this.livingEntity = livingEntity;
 	}
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/LivingEntityMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/LivingEntityMixin.java
@@ -1,0 +1,23 @@
+package net.fabricmc.fabric.mixin.item;
+
+import net.fabricmc.fabric.impl.item.ItemStackExtensions;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(LivingEntity.class)
+abstract class LivingEntityMixin {
+	@Inject(method = "getEquipmentSlotForItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;getEquipmentSlot()Lnet/minecraft/world/entity/EquipmentSlot;"))
+	private void storeLivingEntity(ItemStack arg, CallbackInfoReturnable<EquipmentSlot> cir) {
+		((ItemStackExtensions) (Object) arg).fabric_setLivingEntity((LivingEntity) (Object) this);
+	}
+
+	@Inject(method = "getEquipmentSlotForItem", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/world/item/ItemStack;getEquipmentSlot()Lnet/minecraft/world/entity/EquipmentSlot;"))
+	private void resetLivingEntity(ItemStack arg, CallbackInfoReturnable<EquipmentSlot> cir) {
+		((ItemStackExtensions) (Object) arg).fabric_setLivingEntity(null);
+	}
+}

--- a/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.mixins.json
+++ b/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.mixins.json
@@ -7,11 +7,12 @@
     "EnchantCommandMixin",
     "EnchantmentHelperMixin",
     "EnchantRandomlyLootFunctionMixin",
+    "IItemExtensionMixin",
     "ItemAccessor",
     "ItemMixin",
     "ItemSettingsMixin",
     "ItemStackMixin",
-    "IItemExtensionMixin"
+    "LivingEntityMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Fixes a crash when that method is called, as `Item` cannot be cast to `LivingEntity`.

Note that this *only* fixes the issue when the method is called from `LivingEntity#getEquipmentSlotForItem`. I'm not sure what a more universal fix would be.