### PR TITLE
[1.20.1] Fix bed occupation state check in `LivingEntityMixin#setOccupiedState`

### DIFF
--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/mixin/entity/event/LivingEntityMixin.java
@@ -128,7 +128,7 @@ abstract class LivingEntityMixin {
 		// when the bed doesn't have the property.
 		BlockState originalState = fabric_originalState != null ? fabric_originalState : state;
 
-		if (!EntitySleepEvents.SET_BED_OCCUPATION_STATE.invoker().setBedOccupationState((LivingEntity) (Object) this, pos, originalState, occupied)) {
+		if (EntitySleepEvents.SET_BED_OCCUPATION_STATE.invoker().setBedOccupationState((LivingEntity) (Object) this, pos, originalState, occupied) || originalState.contains(BedBlock.OCCUPIED)) {
 			originalState.setBedOccupied(world, pos, entity, occupied);
 		}
 


### PR DESCRIPTION
Removes the incorrect inversion and checks for `originalState.contains(BedBlock.OCCUPIED)` as the original Fabric API does

Fixes a crash when a Fabric mod allows the player to sleep on blocks that aren't beds (e.g. Spectrum, with its "Night Salts")