### PR TITLE
[1.20.1] Update Forge and mark `TradeOffersTypeAwareBuyForOneEmeraldFactoryMixin` injectors as not required

### DIFF
--- a/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/TradeOffersTypeAwareBuyForOneEmeraldFactoryMixin.java
+++ b/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/TradeOffersTypeAwareBuyForOneEmeraldFactoryMixin.java
@@ -41,7 +41,7 @@ public abstract class TradeOffersTypeAwareBuyForOneEmeraldFactoryMixin {
 	 * We want to prevent this default logic so modded villager types will work.
 	 * So we return an empty stream so an exception is never thrown.
 	 */
-	@Redirect(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/registry/DefaultedRegistry;stream()Ljava/util/stream/Stream;"))
+	@Redirect(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/registry/DefaultedRegistry;stream()Ljava/util/stream/Stream;"), require = 0)
 	private <T> Stream<T> disableVanillaCheck(DefaultedRegistry<VillagerType> instance) {
 		return Stream.empty();
 	}
@@ -49,7 +49,7 @@ public abstract class TradeOffersTypeAwareBuyForOneEmeraldFactoryMixin {
 	/**
 	 * To prevent "item" -> "air" trades, if the result of a type aware trade is air, make sure no offer is created.
 	 */
-	@Inject(method = "create", at = @At(value = "NEW", target = "net/minecraft/village/TradeOffer"), locals = LocalCapture.CAPTURE_FAILEXCEPTION, cancellable = true)
+	@Inject(method = "create", at = @At(value = "NEW", target = "net/minecraft/village/TradeOffer"), locals = LocalCapture.CAPTURE_FAILEXCEPTION, cancellable = true, require = 0)
 	private void failOnNullItem(Entity entity, Random random, CallbackInfoReturnable<TradeOffer> cir, ItemStack buyingItem) {
 		if (buyingItem.isEmpty()) { // Will return true for an "empty" item stack that had null passed in the ctor
 			cir.setReturnValue(null); // Return null to prevent creation of empty trades

--- a/gradle.properties
+++ b/gradle.properties
@@ -67,7 +67,7 @@ fabric-client-tags-api-v1-version=1.1.2
 
 # FFAPI Properties
 loom.platform=forge
-forge_version=1.20.1-47.2.6
+forge_version=1.20.1-47.3.27
 pack_format=15
 forgified_version=1.11.9
 forge_fabric_loader_version=2.6.0+0.15.0+1.20.1


### PR DESCRIPTION
Fixes compatibility with Forge 47.3.26+ while maintaining compatibility with older versions