### PR TITLE
Fix crashes and transfer issues with item/fluid transfer (Fixes #200 & #187)

### DIFF
--- a/fabric-transfer-api-v1/src/main/java/org/sinytra/fabric/transfer_api/compat/FluidStorageFluidHandler.java
+++ b/fabric-transfer-api-v1/src/main/java/org/sinytra/fabric/transfer_api/compat/FluidStorageFluidHandler.java
@@ -11,6 +11,12 @@ import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
 public class FluidStorageFluidHandler implements IFluidHandler {
     private final Storage<FluidVariant> storage;
     private final Int2ObjectMap<StorageView<FluidVariant>> slots;
@@ -44,23 +50,46 @@ public class FluidStorageFluidHandler implements IFluidHandler {
     public boolean isFluidValid(int tank, @NotNull FluidStack stack) {
         return StorageUtil.simulateInsert(storage, NeoCompatUtil.toFluidStorageView(stack), NeoCompatUtil.toFabricBucket(stack.getAmount()), null) > 0;
     }
-
-    @Override
-    public int fill(FluidStack resource, FluidAction action) {
-        try (Transaction transaction = Transaction.openOuter()) {
-            FluidVariant variant = NeoCompatUtil.toFluidStorageView(resource);
-            if (variant.isBlank()) return 0;    // because moving blank resources is a thing in neoforge for some reason? (See https://github.com/AztechMC/Modern-Industrialization/issues/1029)
-            int filled = (int) storage.insert(variant, NeoCompatUtil.toFabricBucket(resource.getAmount()), transaction);
-            if (action.execute()) {
-                transaction.commit();
+    
+    // if a transaction from a fabric context causes a neoforge mod to create a new transaction to a fabric context as part of that first call we need to do so in a new thread
+    private <T> T executeWithTransactionHandling(Supplier<T> operation, T defaultValue) {
+        if (Transaction.isOpen()) {
+            try {
+                return CompletableFuture.supplyAsync(operation).get(1, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException | TimeoutException | ExecutionException e) {
+                return defaultValue;
             }
-            return NeoCompatUtil.toForgeBucket(filled);
+        } else {
+            return operation.get();
         }
     }
 
     @Override
-    public @NotNull FluidStack drain(FluidStack resource, FluidAction action) {
-        if (!resource.isEmpty()) {
+    public int fill(FluidStack resource, @NotNull FluidAction action) {
+        
+        // because moving blank/empty fluid resources is a thing in neoforge for some reason? (See https://github.com/AztechMC/Modern-Industrialization/issues/1029)
+        if (resource.isEmpty()) return 0;
+        
+        return executeWithTransactionHandling(() -> {
+            try (Transaction transaction = Transaction.openOuter()) {
+                FluidVariant variant = NeoCompatUtil.toFluidStorageView(resource);
+                int filled = (int) storage.insert(variant, NeoCompatUtil.toFabricBucket(resource.getAmount()), transaction);
+                if (action.execute()) {
+                    transaction.commit();
+                }
+                return NeoCompatUtil.toForgeBucket(filled);
+            }
+        }, 0);
+    }
+
+    @Override
+    public @NotNull FluidStack drain(FluidStack resource, @NotNull FluidAction action) {
+        
+        if (resource.isEmpty()) {
+            return FluidStack.EMPTY;
+        }
+        
+        return executeWithTransactionHandling(() -> {
             try (Transaction transaction = Transaction.openOuter()) {
                 FluidVariant variant = NeoCompatUtil.toFluidStorageView(resource);
                 int drained = (int) storage.extract(variant, NeoCompatUtil.toFabricBucket(resource.getAmount()), transaction);
@@ -69,22 +98,23 @@ public class FluidStorageFluidHandler implements IFluidHandler {
                 }
                 return NeoCompatUtil.toForgeFluidStack(variant, drained);
             }
-        }
-        return FluidStack.EMPTY;
+        }, FluidStack.EMPTY);
     }
 
     @Override
-    public @NotNull FluidStack drain(int maxDrain, FluidAction action) {
-        for (StorageView<FluidVariant> view : storage.nonEmptyViews()) {
-            try (Transaction transaction = Transaction.openOuter()) {
-                FluidVariant resource = view.getResource();
-                int drained = (int) storage.extract(resource, NeoCompatUtil.toFabricBucket(maxDrain), transaction);
-                if (action.execute()) {
-                    transaction.commit();
+    public @NotNull FluidStack drain(int maxDrain, @NotNull FluidAction action) {
+        return executeWithTransactionHandling(() -> {
+            for (StorageView<FluidVariant> view : storage.nonEmptyViews()) {
+                try (Transaction transaction = Transaction.openOuter()) {
+                    FluidVariant resource = view.getResource();
+                    int drained = (int) storage.extract(resource, NeoCompatUtil.toFabricBucket(maxDrain), transaction);
+                    if (action.execute()) {
+                        transaction.commit();
+                    }
+                    return NeoCompatUtil.toForgeFluidStack(resource, drained);
                 }
-                return NeoCompatUtil.toForgeFluidStack(resource, drained);
             }
-        }
-        return FluidStack.EMPTY;
+            return FluidStack.EMPTY;
+        }, FluidStack.EMPTY);
     }
 }

--- a/fabric-transfer-api-v1/src/main/java/org/sinytra/fabric/transfer_api/compat/FluidStorageFluidHandler.java
+++ b/fabric-transfer-api-v1/src/main/java/org/sinytra/fabric/transfer_api/compat/FluidStorageFluidHandler.java
@@ -49,6 +49,7 @@ public class FluidStorageFluidHandler implements IFluidHandler {
     public int fill(FluidStack resource, FluidAction action) {
         try (Transaction transaction = Transaction.openOuter()) {
             FluidVariant variant = NeoCompatUtil.toFluidStorageView(resource);
+            if (variant.isBlank()) return 0;    // because moving blank resources is a thing in neoforge for some reason? (See https://github.com/AztechMC/Modern-Industrialization/issues/1029)
             int filled = (int) storage.insert(variant, NeoCompatUtil.toFabricBucket(resource.getAmount()), transaction);
             if (action.execute()) {
                 transaction.commit();

--- a/fabric-transfer-api-v1/src/main/java/org/sinytra/fabric/transfer_api/compat/FluidStorageFluidHandler.java
+++ b/fabric-transfer-api-v1/src/main/java/org/sinytra/fabric/transfer_api/compat/FluidStorageFluidHandler.java
@@ -55,7 +55,7 @@ public class FluidStorageFluidHandler implements IFluidHandler {
     private <T> T executeWithTransactionHandling(Supplier<T> operation, T defaultValue) {
         if (Transaction.isOpen()) {
             try {
-                return CompletableFuture.supplyAsync(operation).get(1, TimeUnit.MILLISECONDS);
+                return CompletableFuture.supplyAsync(operation).get(10, TimeUnit.MICROSECONDS);
             } catch (InterruptedException | TimeoutException | ExecutionException e) {
                 return defaultValue;
             }

--- a/fabric-transfer-api-v1/src/main/java/org/sinytra/fabric/transfer_api/compat/ItemStorageItemHandler.java
+++ b/fabric-transfer-api-v1/src/main/java/org/sinytra/fabric/transfer_api/compat/ItemStorageItemHandler.java
@@ -44,6 +44,7 @@ public class ItemStorageItemHandler implements IItemHandler {
     public @NotNull ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
         try (Transaction transaction = Transaction.openOuter()) {
             ItemVariant resource = ItemVariant.of(stack);
+            if (resource.isBlank()) return ItemStack.EMPTY;
             int inserted = (int) storage.insert(resource, stack.getCount(), transaction);
             if (!simulate) {
                 transaction.commit();


### PR DESCRIPTION
Refactor some things in the fluid transfer api section to prevent crashes with empty fluid variants in the fill() method. Also update the fill() and drain() methods to operate inside new threads if a transaction is already open (this happens if a mod inserts things into another inventory as part of the insert() call, such as a tesseract which does not have an internal tank. When the transfer is called from a fabric context, a new transaction is opened. This transaction context is then lost during the insert method of the neoforge mod, so FFAPI tries to create a new transaction on the same thread, which causes a crash). 

This fix is inspired by the connector extras energy bridge, which also opens new threads for transactions.

This has been tested by building the mod and then doing various operations with the tesseract mod. Pipes and tanks from Mekanism, Oritech and Modern Industrialization were tested and no longer crash (while they did before in the same setup).

Also added a new check for blank item resource variants in the insertItem() calls, similar to the existing ones in extractItem(). I also got reports from this causing crashes.