### PR TITLE
Ensure connection is active before initializing addon

### DIFF
--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/ClientPlayNetworkHandlerMixin.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/mixin/networking/client/ClientPlayNetworkHandlerMixin.java
@@ -49,6 +49,10 @@ abstract class ClientPlayNetworkHandlerMixin extends ClientCommonPacketListenerI
 
     @Inject(method = "<init>", at = @At("RETURN"))
     private void initAddon(CallbackInfo ci) {
+        if (!this.getConnection().isConnected()) {
+            return;
+        }
+
         Set<ResourceLocation> channels = ChannelAttributes.getOrCreateCommonChannels(this.getConnection(), this.protocol());
         NeoClientCommonNetworking.onRegisterPacket((ClientPacketListener) (Object) this, channels);
 


### PR DESCRIPTION
In some cases, a connection may not have any channel. In this case, `ChannelAttributes.getOrCreateCommonChannels` shouldn't be called because it creates a `NullPointerException`. If the channel is `null`, it should just not continue with collecting channels and initializing it for the addon. 

Maybe, we should also not check `isConnected` but instead  `isConnecting` since `isConnected` also checks for `Channel#isOpen` and `isConnecting` only checks if `channel` is null. 