### PR TITLE
Re-implement FabricShaderProgram for mods that use it

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/FabricShaderProgram.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/FabricShaderProgram.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.client.rendering;
+
+import java.io.IOException;
+
+import com.mojang.blaze3d.vertex.VertexFormat;
+import net.minecraft.client.renderer.ShaderInstance;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceProvider;
+
+public final class FabricShaderProgram extends ShaderInstance {
+	public FabricShaderProgram(ResourceProvider factory, ResourceLocation name, VertexFormat format) throws IOException {
+		super(factory, name, format);
+	}
+
+	/**
+	 * Rewrites the input string containing an identifier
+	 * with the namespace of the id in the front instead of in the middle.
+	 *
+	 * <p>Example: {@code shaders/core/my_mod:xyz} -> {@code my_mod:shaders/core/xyz}
+	 *
+	 * @param input       the raw input string
+	 * @param containedId the ID contained within the input string
+	 * @return the corrected full ID string
+	 */
+	public static ResourceLocation rewriteAsId(String input, String containedId) {
+		ResourceLocation contained = ResourceLocation.parse(containedId);
+		return contained.withPath(path -> input.replace(containedId, path));
+	}
+}


### PR DESCRIPTION
i.e. [Satin API](https://modrinth.com/mod/satin-api/)

The `<init>` method originally used `name.toString()`, so it was adjusted to just use NeoForge's method instead, which already takes a `ResourceLocation`.

(this is enough to get Satin API working! although it seems to have issues with ModernFix's Dynamic Resources)

EDIT: This PR is NOT enough to get Satin API working; I'm not sure why I said that :p  
Some mixins still fail; I've worked around them all in one of my "modpack tweaks" mods: https://github.com/unilock/sheepish