### PR TITLE
Fix Item/Block color API

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/BlockColorsMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/BlockColorsMixin.java
@@ -25,15 +25,25 @@ import net.minecraft.world.level.block.Block;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Map;
 
 @Mixin(BlockColors.class)
 public class BlockColorsMixin implements ColorProviderRegistryImpl.ColorMapperHolder<Block, BlockColor> {
 	@Shadow
 	@Final
-	private IdMapper<BlockColor> blockColors;
+	private Map<Block, BlockColor> blockColors;
+
+	@Inject(method = "createDefault", at = @At("RETURN"))
+	private static void createDefault(CallbackInfoReturnable<BlockColors> info) {
+		ColorProviderRegistryImpl.BLOCK.initialize(info.getReturnValue());
+	}
 
 	@Override
 	public BlockColor get(Block block) {
-		return blockColors.byId(BuiltInRegistries.BLOCK.getId(block));
+		return blockColors.get(block);
 	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/ItemColorsMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/ItemColorsMixin.java
@@ -17,23 +17,35 @@
 package net.fabricmc.fabric.mixin.client.rendering;
 
 import net.fabricmc.fabric.impl.client.rendering.ColorProviderRegistryImpl;
+import net.minecraft.client.color.block.BlockColors;
 import net.minecraft.client.color.item.ItemColor;
 import net.minecraft.client.color.item.ItemColors;
 import net.minecraft.core.IdMapper;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.level.ItemLike;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Map;
 
 @Mixin(ItemColors.class)
 public class ItemColorsMixin implements ColorProviderRegistryImpl.ColorMapperHolder<ItemLike, ItemColor> {
 	@Shadow
 	@Final
-	private IdMapper<ItemColor> itemColors;
+	private Map<Item, ItemColor> itemColors;
+
+	@Inject(method = "createDefault", at = @At("RETURN"))
+	private static void createDefault(BlockColors blockMap, CallbackInfoReturnable<ItemColors> info) {
+		ColorProviderRegistryImpl.ITEM.initialize(info.getReturnValue());
+	}
 
 	@Override
 	public ItemColor get(ItemLike item) {
-		return itemColors.byId(BuiltInRegistries.ITEM.getId(item.asItem()));
+		return itemColors.get(item.asItem());
 	}
 }

--- a/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
+++ b/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
@@ -5,11 +5,13 @@
   "client": [
     "ArmorFeatureRendererMixin",
     "AtlasSourceManagerAccessor",
+    "BlockColorsMixin",
     "BuiltinModelItemRendererMixin",
     "CapeFeatureRendererMixin",
     "DimensionEffectsAccessor",
     "EntityModelLayersAccessor",
     "EntityRenderersMixin",
+    "ItemColorsMixin",
     "LivingEntityRendererAccessor",
     "TooltipComponentMixin",
     "WorldRendererMixin",


### PR DESCRIPTION
This fixes a mixin issue that causes a crash when [Spectrum](https://github.com/DaFuqs/Spectrum) is used with Sinytra Connector, due to an API required by Spectrum not being fully implemented.